### PR TITLE
fix(BasePagination): update the tests for emitted events

### DIFF
--- a/src/components/__tests__/BasePagination.spec.ts
+++ b/src/components/__tests__/BasePagination.spec.ts
@@ -39,11 +39,7 @@ describe("BasePagination.vue", () => {
       },
     });
     wrapper.find('[data-testid="first"]').trigger("click");
-    const emitted = wrapper.emitted("pagechanged");
-
-    if (emitted?.length) {
-      expect(emitted[0]).toEqual([1]);
-    }
+    expect(wrapper.emitted("pagechanged")).toEqual([[1]]);
   });
 
   it("goes to the previous page", () => {
@@ -55,11 +51,7 @@ describe("BasePagination.vue", () => {
       },
     });
     wrapper.find('[data-testid="previous"]').trigger("click");
-    const emitted = wrapper.emitted("pagechanged");
-
-    if (emitted?.length) {
-      expect(emitted[0]).toEqual([2]);
-    }
+    expect(wrapper.emitted("pagechanged")).toEqual([[2]]);
   });
 
   it("goes to the selected page", () => {
@@ -71,11 +63,7 @@ describe("BasePagination.vue", () => {
       },
     });
     wrapper.find('[data-testid="page"]').trigger("click");
-    const emitted = wrapper.emitted("pagechanged");
-
-    if (emitted?.length) {
-      expect(emitted[0]).toEqual([2]);
-    }
+    expect(wrapper.emitted("pagechanged")).toEqual([[2]]);
   });
 
   it("goes to the next page", () => {
@@ -87,11 +75,7 @@ describe("BasePagination.vue", () => {
       },
     });
     wrapper.find('[data-testid="next"]').trigger("click");
-    const emitted = wrapper.emitted("pagechanged");
-
-    if (emitted?.length) {
-      expect(emitted[0]).toEqual([4]);
-    }
+    expect(wrapper.emitted("pagechanged")).toEqual([[4]]);
   });
 
   it("goes to the last page", () => {
@@ -103,11 +87,7 @@ describe("BasePagination.vue", () => {
       },
     });
     wrapper.find('[data-testid="last"]').trigger("click");
-    const emitted = wrapper.emitted("pagechanged");
-
-    if (emitted?.length) {
-      expect(emitted[0]).toEqual([10]);
-    }
+    expect(wrapper.emitted("pagechanged")).toEqual([[10]]);
   });
 
   it("renders active pagination element", () => {


### PR DESCRIPTION
## What did you do?

The tests where the `emitted` is used, used `if` because without it there was a TypeScript error `Object is possibly 'undefined'`. Since `expect` was inside the `if`, the test always passed, even if the event was not emitted. For this reason, the tests were changed to not use `if`, but at the same time did not have the `Object is possibly 'undefined'` error or the `forbiiden non-null assertion` warning.

- fix(BasePagination): update the tests for emitted events