### PR TITLE
fix: image elements do not have [alt] attributes

### DIFF
--- a/src/components/CategoriesListItem.vue
+++ b/src/components/CategoriesListItem.vue
@@ -17,7 +17,7 @@ defineProps({
       <div class="category__image">
         <img
           :src="category.assets[0].url"
-          :alt="category.assets[0].description || undefined"
+          :alt="category.description || undefined"
         />
       </div>
       <div class="category__details">


### PR DESCRIPTION
## What did you do?

The Assets object contains a description, but the API doesn't return anything and there is no way to set the description for assets in the commerce.js dashboard. Due to this, there was an accessibility error in Lighthouse because the images for the categories didn't have alt attributes. 

Updated the alt attributes to use the category description instead of the assets description.
