### PR TITLE
fix(CheckoutView): make input for zip code as readonly

### DIFF
--- a/src/views/CheckoutView.vue
+++ b/src/views/CheckoutView.vue
@@ -185,7 +185,7 @@ const handleCapture = async () => {
                 type="text"
                 v-model="checkoutForm.shipping.postal_zip_code"
                 name="postalZipCode"
-                required
+                readonly
               />
               <span class="input-group__bar"></span>
               <label class="input-group__label" for="postalZipCode"
@@ -466,7 +466,7 @@ section {
 
       @media (min-width: 768px) {
         display: block;
-        width: 4rem;
+        min-width: 4rem;
         height: 4rem;
         object-fit: cover;
       }


### PR DESCRIPTION
## What did you do?

Updated the input for zip/postal code as readonly. 

The project uses a test payment gateway. The test gateway requires both a zip code and a state/province to place an order. Once the zip code is entered, the backend checks if the zip code matches the state/province, the problem is that `chec` doesn't provide a database of what codes are allowed/recognised for which states. For this reason, even if the user uses the correct zip code for a state, but such a code is not in `chec's` database, an error occurs and the order fails. This also makes no sense to create own validator, as there would be differences in zip codes so errors would still occur. There is a plan to [auto-select the county/state field when a postal code is entered that is recognized](https://github.com/chec/commerce.js/issues/193), but in the current state, to make sure the user can place a test order, I changed the zip code as readonly and limited the state/province to one state (CA). 

