### PR TITLE
fix(ShopView): update the category variable

### DIFF
--- a/src/views/ShopView.vue
+++ b/src/views/ShopView.vue
@@ -16,11 +16,13 @@ const router = useRouter();
 const route = useRoute();
 
 const page = ref<number>(Number(route.query.page) || 1);
-const category = ref<string | null>(null);
 const recordsPerPage = ref<number>(6);
 const isOpen = ref<boolean>(false);
 const selected = ref<string>(
   route.query.sortDirection ? String(route.query.sortDirection) : "latest"
+);
+const category = ref<string | null>(
+  route.query.category ? String(route.query.category) : null
 );
 
 const { categories } = useCategories();
@@ -28,7 +30,7 @@ const { products, metadata, error, isLoading, fetchData } = useProducts({
   limit: recordsPerPage.value,
   page: page.value,
   query: route.query.search,
-  category_id: route.query.category,
+  category_id: category.value,
   sortBy: selected.value === "latest" ? "created_at" : "price",
   sortDirection: selected.value === "latest" ? "asc" : selected.value,
 });


### PR DESCRIPTION
## What did you do?

There was a bug when a user used the category list on the home page or categories page and selected a specific category, and then while on the store page tried to sort products, instead of the sorted products from the category, all products appeared. This was due to the fact that the value of category was null so when the user selected sort by which resulted in a request for sorted data, the category was missing and all products were returned. Updated the category variable to check if there is a `route.query.category` and if so, take its value. 
