### PR TITLE
fix: add permissions key in workflows

### DIFF
--- a/.github/workflows/netlify-merge.yml
+++ b/.github/workflows/netlify-merge.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+permissions: write-all
 jobs:
   build:
     runs-on: ubuntu-18.04

--- a/.github/workflows/netlify-pull-request.yml
+++ b/.github/workflows/netlify-pull-request.yml
@@ -1,5 +1,6 @@
 name: Deploy to Netlify on PR
 on: pull_request
+permissions: write-all
 jobs:
   build:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
## What did you do?

By default, GitHub Actions workflows triggered by Dependabot get a `GITHUB_TOKEN` with read-only permissions. Because of this, the action fails when triggered by Dependabot and is unable to deploy to Netlify. Added the `permissions` key in workflows to increase the access for the token.