### PR TITLE
fix(ShopView): update modal prop from visible to visibleModal

### DIFF
--- a/src/views/ShopView.vue
+++ b/src/views/ShopView.vue
@@ -127,7 +127,8 @@ watch(
     <section id="shop">
       <BaseHeadline type="h1" text="shop" :line="true" />
       <div v-if="products?.length" class="shop__products">
-        <BaseModal :visible="isOpen" @close="toggleModal">
+        <BaseModal :visibleModal="isOpen" @close="toggleModal">
+          <template v-slot:header>Categories</template>
           <template v-slot:content>
             <div class="shop__categories">
               <ul class="shop__categories-list">


### PR DESCRIPTION
## What did you do?

The modal component was updated some time ago, and the `visible` prop was renamed to `visibleModal`, but the modal in the `ShopView` was not updated and still used the old name. Because of this, the modal didn't  work and categories for smaller screens were not displayed when the categories button was clicked. The modal also didn't have a header.